### PR TITLE
Remove extraneous 'print' statement

### DIFF
--- a/pydpkg/dsc.py
+++ b/pydpkg/dsc.py
@@ -203,7 +203,6 @@ class Dsc(_Dbase):
                 if line:  # grrr
                     found.append(line.strip().split(" "))
             files = [x[2] for x in found]
-            print(f"Files: {files}")
             if base not in files:
                 self._log.debug("dsc file not found in %s: %s", key, base)
                 self._log.debug("getting hasher for %s", hashtype)


### PR DESCRIPTION
It appears to be leftover from debugging? Regardless I don't believe it should be there.